### PR TITLE
setCurrentUser() is deprecated since 6.6. Change it with the new setCurrentUserReference()

### DIFF
--- a/Command/CreateContentCommand.php
+++ b/Command/CreateContentCommand.php
@@ -35,13 +35,13 @@ class CreateContentCommand extends ContainerAwareCommand
 
     protected function execute( InputInterface $input, OutputInterface $output )
     {
-/** @var $repository \eZ\Publish\API\Repository\Repository */
-$repository = $this->getContainer()->get( 'ezpublish.api.repository' );
-$contentService = $repository->getContentService();
-$locationService = $repository->getLocationService();
-$contentTypeService = $repository->getContentTypeService();
+        /** @var $repository \eZ\Publish\API\Repository\Repository */
+        $repository = $this->getContainer()->get( 'ezpublish.api.repository' );
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        $contentTypeService = $repository->getContentTypeService();
 
-        $repository->setCurrentUser( $repository->getUserService()->loadUser( 14 ) );
+        $this->getRepository()->getPermissionResolver()->setCurrentUserReference( $this->getRepository()->getUserService()->loadUser( 14 ) );
 
         // fetch the input arguments
         $parentLocationId = $input->getArgument( 'parentLocationId' );


### PR DESCRIPTION
setCurrentUser() is deprecated since 6.6, to be removed. Use PermissionResolver::setCurrentUserReference() like indicated in :
https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/SignalSlot/Repository.php#L202